### PR TITLE
EnderXPStorage improvements

### DIFF
--- a/AV-EnderXPStorage/data/av-enderxpstorage/functions/attempt_retrieve.mcfunction
+++ b/AV-EnderXPStorage/data/av-enderxpstorage/functions/attempt_retrieve.mcfunction
@@ -19,5 +19,11 @@ xp add @s[scores={av-xp-dummy=4}] 4 points
 scoreboard players remove @s[scores={av-xp-dummy=5}] av-stored-xp 5
 xp add @s[scores={av-xp-dummy=5}] 5 points
 
+# play sound
+execute as @s[scores={av-xp-dummy=1..}] run playsound minecraft:item.bottle.empty player @a ~ ~ ~ 1 2
+
+# emit particle
+execute as @s[scores={av-xp-dummy=1..}] run particle minecraft:nautilus ~ ~2 ~ 0.2 0 0.2 3 10 force
+
 # show title
-title @s actionbar {"color":"dark_purple","bold":true,"text":"","extra":["Ender XP: ",{"score":{"name":"*","objective":"av-stored-xp"}}]}
+title @s actionbar [{"color":"green","bold":true,"text":"▲ "},{"color":"dark_purple","bold":true,"text":"","extra":["Ender XP: ",{"score":{"name":"*","objective":"av-stored-xp"}}]},{"color":"green","bold":true,"text":" ▲"}]

--- a/AV-EnderXPStorage/data/av-enderxpstorage/functions/attempt_store.mcfunction
+++ b/AV-EnderXPStorage/data/av-enderxpstorage/functions/attempt_store.mcfunction
@@ -39,8 +39,14 @@ xp add @s[scores={av-xp-dummy=42}] -10 points
 scoreboard players add @s[scores={av-xp-dummy=43}] av-stored-xp 8
 xp add @s[scores={av-xp-dummy=43}] -20 points
 
+# play sound
+execute as @s[scores={av-xp-dummy=1..}] run playsound minecraft:item.bottle.fill_dragonbreath player @a ~ ~ ~ 1 2
+
+# emit particle
+execute as @s[scores={av-xp-dummy=1..}] run particle minecraft:item minecraft:ender_eye ~ ~ ~ .2 .5 .2 0 10 force
+
 # show title
-title @s actionbar {"color":"dark_purple","bold":true,"text":"","extra":["Ender XP: ",{"score":{"name":"*","objective":"av-stored-xp"}}]}
+title @s actionbar [{"color":"red","bold":true,"text":"▼ "},{"color":"dark_purple","bold":true,"text":"","extra":["Ender XP: ",{"score":{"name":"*","objective":"av-stored-xp"}}]},{"color":"red","bold":true,"text":" ▼"}]
 
 # give advancement if storage happened
 advancement grant @s[scores={av-xp-dummy=1..}] until av-enderxpstorage:untouchable_xp

--- a/AV-EnderXPStorage/data/av-enderxpstorage/functions/tick.mcfunction
+++ b/AV-EnderXPStorage/data/av-enderxpstorage/functions/tick.mcfunction
@@ -1,5 +1,8 @@
 # handle players that are standing on an ender chest and are looking up or down
 
+# players on a chest shows their ender xp
+execute as @a at @s if block ~ ~ ~ minecraft:ender_chest run title @s actionbar {"color":"dark_purple","bold":true,"text":"","extra":["Ender XP: ",{"score":{"name":"*","objective":"av-stored-xp"}}]}
+
 # players looking down on an ender chest are attempting to store xp
 execute as @a[x_rotation=89..90] at @s if block ~ ~ ~ minecraft:ender_chest run function av-enderxpstorage:attempt_store
 


### PR DESCRIPTION
This fork allows EnderXPStorage to:
- Play sounds and emit particles when retrieving/storing XP
- Shows the amount of XP stored when standing on an ender chest
- Shows symbols on the action bar when retrieving/storing XP [[example]](https://i.imgur.com/ezgqmsT.png)